### PR TITLE
ci: use a github environment for deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     env:
       STACK_NAME: stac-fastapi-geoparquet-labs-375
-      STACK_STAGE: dev
+      STACK_STAGE: ${{ vars.STAGE }}
       STACK_OWNER: labs-375
       STACK_RELEASE: ${{ github.event.release.tag_name }}
       STACK_BUCKET_NAME: stac-fastapi-geoparquet-devseed


### PR DESCRIPTION
I added one manually here: https://github.com/developmentseed/labs-375-stac-geoparquet-backend/settings/environments/5310224499/edit. I _think_ this is the best way to give ourselves more configuration at the Github level down the road, but let me know if you don't think this is worth it.

(did some nit cleanup on the workflow)