### PR TITLE
feat: configure custom domain for API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
       STACK_BUCKET_NAME: stac-fastapi-geoparquet-labs-375
       STACK_COLLECTIONS_KEY: collections.json
       STACK_RATE_LIMIT: 10
+      STACK_API_CUSTOM_DOMAIN: ${{ vars.API_CUSTOM_DOMAIN }}
+      STACK_ACM_CERTIFICATE_ARN: ${{ vars.ACM_CERTIFICATE_ARN }}
     environment:
       name: development
       url: ${{ steps.deploy.outputs.api_url }}

--- a/docs/katas/8_planetary_computer.ipynb
+++ b/docs/katas/8_planetary_computer.ipynb
@@ -1318,6 +1318,7 @@
     "YEARS = [2024]\n",
     "number_of_items = 0\n",
     "\n",
+    "\n",
     "def clean_dict(item: dict[str, Any]) -> dict[str, Any]:\n",
     "    for key, value in item.items():\n",
     "        if hasattr(value, \"tolist\"):\n",
@@ -1328,6 +1329,7 @@
     "            item[key] = clean_dict(value)\n",
     "    return item\n",
     "\n",
+    "\n",
     "Path(\"/Users/gadomski/Desktop/sentinel-2-l2a-fixed.parquet\").mkdir(exist_ok=True)\n",
     "\n",
     "for path in Path(\"/Users/gadomski/Desktop/sentinel-2-l2a.parquet\").glob(\"*.parquet\"):\n",
@@ -1337,9 +1339,7 @@
     "        items = []\n",
     "        for feature in tqdm(feature_collection[\"features\"]):\n",
     "            item = clean_dict(feature[\"properties\"])\n",
-    "            new_item = {\n",
-    "                \"geometry\": feature[\"geometry\"]\n",
-    "            }\n",
+    "            new_item = {\"geometry\": feature[\"geometry\"]}\n",
     "            properties = {}\n",
     "            for key, value in item.items():\n",
     "                if key in TOP_LEVEL_ATTRIBUTES:\n",
@@ -1355,7 +1355,7 @@
     "            ),\n",
     "            items,\n",
     "        )\n",
-    "        print(number_of_items, \"items\")\n"
+    "        print(number_of_items, \"items\")"
    ]
   },
   {

--- a/infrastructure/aws/config.py
+++ b/infrastructure/aws/config.py
@@ -30,6 +30,10 @@ class Config(BaseSettings):
         "maximum average requests per second over an extended period of time",
     ] = 10
 
+    # custom domain
+    api_custom_domain: Optional[str] = None
+    acm_certificate_arn: Optional[str] = None
+
     # vpc
     nat_gateway_count: int = 0
 

--- a/infrastructure/aws/stacks/app.py
+++ b/infrastructure/aws/stacks/app.py
@@ -46,5 +46,25 @@ class AppStack(Stack):
         geoparquet_api = GeoparquetApiLambda(
             self, "geoparquet-api", config=config, bucket=bucket
         )
-        assert geoparquet_api.url
-        CfnOutput(self, "GeoparquetApiURL", value=geoparquet_api.url)
+
+        if geoparquet_api.domain_name:
+            CfnOutput(
+                self,
+                "ApiGatewayDomainNameTarget",
+                value=geoparquet_api.domain_name.regional_domain_name,
+                description="The target for the CNAME/ALIAS record",
+            )
+            CfnOutput(
+                self,
+                "GeoparquetApiURL",
+                value=f"https://{geoparquet_api.domain_name.name}",
+                description="The custom domain URL for the API",
+            )
+        else:
+            assert geoparquet_api.stage.url
+            CfnOutput(
+                self,
+                "GeoparquetApiURL",
+                value=geoparquet_api.stage.url,
+                description="The default stage URL for the API",
+            )


### PR DESCRIPTION
The new certificate for `*.labs.eoapi.dev` is still pending validation but I updated the deployment vars in the `dev` environment with the values we need to deploy this to `stac-geoparquet.labs.eoapi.dev`. After we deploy the stack we will need to configure the alias record in Route53.